### PR TITLE
Lock install routine to only allow for one execution

### DIFF
--- a/includes/class-suffice-install.php
+++ b/includes/class-suffice-install.php
@@ -80,6 +80,13 @@ class ST_Install {
 	public static function install() {
 		global $wpdb;
 
+		if ( 'yes' === get_transient( 'st_installing' ) ) {
+			return;
+		}
+
+		// If we made it till here nothing is running yet, lets set the transient now.
+		set_transient( 'st_installing', 'yes', MINUTE_IN_SECONDS * 10 );
+
 		if ( ! defined( 'ST_INSTALLING' ) ) {
 			define( 'ST_INSTALLING', true );
 		}
@@ -111,6 +118,8 @@ class ST_Install {
 		}
 
 		self::update_ft_version();
+
+		delete_transient( 'st_installing' );
 
 		// Flush rules after install
 		do_action( 'suffice_toolkit_flush_rewrite_rules' );


### PR DESCRIPTION
Due to the check_version method running on init it can fire multiple times during a page load causing race condition when doing a new install.

This PR adds a transient lock to ensure we are only running this once.