### PR TITLE
fix changelog formatting in readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -32,7 +32,7 @@ Get free support at https://themegrill.com/support-forum/
 
 == Changelog ==
 
-== 1.0.6 - 08-07-2021 ==
+= 1.0.6 - 08-07-2021 =
 * Tweak - Updated `Tested up to` to 5.7
 
 = 1.0.4 - 2019-06-20 =


### PR DESCRIPTION
This PR fixes formatting of the Changelog section in the `readme.txt` file to ensure the changelog details appear on the [Development tab](https://wordpress.org/plugins/suffice-toolkit/#developers) instead of the [Details tab](https://wordpress.org/plugins/suffice-toolkit/#description) on WordPress.org.